### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/javascripts/written_book.html
+++ b/javascripts/written_book.html
@@ -53,8 +53,8 @@
     <script src="../sheep.js"></script>
     <script>
 /*
-  http://minecraft.gamepedia.com/Book_and_quill#Data_values
-  http://minecraft.gamepedia.com/Commands#Raw_JSON_text
+  http://minecraft.wiki/w/Book_and_quill#Data_values
+  http://minecraft.wiki/w/Commands#Raw_JSON_text
   http://www.minecraftforum.net/forums/minecraft-discussion/redstone-discussion-and/351959-1-9-json-text-component-for-tellraw-title-books
 */
     </script>


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.
